### PR TITLE
add: target _blank for hacktoberfest website

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
 						<div id="date-countdown"></div>
 						<p>
 							<a href="#projects" class="btn btn-primary py-3 px-4 mr-3">View Projects</a>
-							<a href="https://hacktoberfest.digitalocean.com/" class="more light">Learn More</a>
+							<a href="https://hacktoberfest.digitalocean.com/" class="more light" target="_blank">Learn More</a>
 						</p>
 					</div>
 				</div>


### PR DESCRIPTION
*Minor change*
Previously the ```Learn More``` button led to the Hacktoberfest website opening on the same page as our website which may be disruptive. This PR fixes that and opens Hacktoberfest website as a new tab.